### PR TITLE
feat: add support for fetching subset of dataset by type

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": ["main"]
+  "branches": ["main", {"name": "add-type-allowlist", "prerelease": true}]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": ["main", {"name": "add-type-allowlist", "prerelease": true}]
+  "branches": ["main", { "name": "add-type-allowlist", "prerelease": true }]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,4 @@
 {
   "extends": "@sanity/semantic-release-preset",
-  "branches": ["main", { "name": "add-type-allowlist", "prerelease": true }]
+  "branches": ["main"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,6 @@ All notable changes to this project will be documented in this file. See
 
 ### Features
 
-- add support for fetching subset of dataset by type ([c4e9b83](https://github.com/sanity-io/preview-kit/commit/c4e9b8375bcd0fcc5d23734881b318a5847f18dd))
-
-### Bug Fixes
-
-- forward `allowTypes` to `@sanity/groq-store` ([37930d0](https://github.com/sanity-io/preview-kit/commit/37930d000ead44e34be97953345a0a58bfd25aec))
-
-## [1.2.0-add-type-allowlist.1](https://github.com/sanity-io/preview-kit/compare/v1.1.3...v1.2.0-add-type-allowlist.1) (2022-11-14)
-
-### Features
-
-- add support for fetching subset of dataset by type ([c4e9b83](https://github.com/sanity-io/preview-kit/commit/c4e9b8375bcd0fcc5d23734881b318a5847f18dd))
-
-### Bug Fixes
-
-- forward `allowTypes` to `@sanity/groq-store` ([37930d0](https://github.com/sanity-io/preview-kit/commit/37930d000ead44e34be97953345a0a58bfd25aec))
-
-## [1.2.0-add-type-allowlist.1](https://github.com/sanity-io/preview-kit/compare/v1.1.3...v1.2.0-add-type-allowlist.1) (2022-11-14)
-
-### Features
-
 - add support for fetching subset of dataset by type ([768a6da](https://github.com/sanity-io/preview-kit/commit/768a6dab73a8cfd2e5e8f23b4f7bbeac09cc16b3))
 
 ## [1.1.3](https://github.com/sanity-io/preview-kit/compare/v1.1.2...v1.1.3) (2022-11-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 All notable changes to this project will be documented in this file. See
 [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.0-add-type-allowlist.1](https://github.com/sanity-io/preview-kit/compare/v1.1.3...v1.2.0-add-type-allowlist.1) (2022-11-14)
+
+### Features
+
+- add support for fetching subset of dataset by type ([768a6da](https://github.com/sanity-io/preview-kit/commit/768a6dab73a8cfd2e5e8f23b4f7bbeac09cc16b3))
+
 ## [1.1.3](https://github.com/sanity-io/preview-kit/compare/v1.1.2...v1.1.3) (2022-11-11)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ All notable changes to this project will be documented in this file. See
 
 ### Features
 
+- add support for fetching subset of dataset by type ([c4e9b83](https://github.com/sanity-io/preview-kit/commit/c4e9b8375bcd0fcc5d23734881b318a5847f18dd))
+
+### Bug Fixes
+
+- forward `allowTypes` to `@sanity/groq-store` ([37930d0](https://github.com/sanity-io/preview-kit/commit/37930d000ead44e34be97953345a0a58bfd25aec))
+
+## [1.2.0-add-type-allowlist.1](https://github.com/sanity-io/preview-kit/compare/v1.1.3...v1.2.0-add-type-allowlist.1) (2022-11-14)
+
+### Features
+
 - add support for fetching subset of dataset by type ([768a6da](https://github.com/sanity-io/preview-kit/commit/768a6dab73a8cfd2e5e8f23b4f7bbeac09cc16b3))
 
 ## [1.1.3](https://github.com/sanity-io/preview-kit/compare/v1.1.2...v1.1.3) (2022-11-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project will be documented in this file. See
 
 ### Features
 
+- add support for fetching subset of dataset by type ([c4e9b83](https://github.com/sanity-io/preview-kit/commit/c4e9b8375bcd0fcc5d23734881b318a5847f18dd))
+
+### Bug Fixes
+
+- forward `allowTypes` to `@sanity/groq-store` ([37930d0](https://github.com/sanity-io/preview-kit/commit/37930d000ead44e34be97953345a0a58bfd25aec))
+
+## [1.2.0-add-type-allowlist.1](https://github.com/sanity-io/preview-kit/compare/v1.1.3...v1.2.0-add-type-allowlist.1) (2022-11-14)
+
+### Features
+
 - add support for fetching subset of dataset by type ([768a6da](https://github.com/sanity-io/preview-kit/commit/768a6dab73a8cfd2e5e8f23b4f7bbeac09cc16b3))
 
 ## [1.1.3](https://github.com/sanity-io/preview-kit/compare/v1.1.2...v1.1.3) (2022-11-11)

--- a/app/(preview)/next13-token/page.tsx
+++ b/app/(preview)/next13-token/page.tsx
@@ -1,7 +1,5 @@
-import { type FooterProps, Footer, query as footerQuery } from 'app/Footer'
+import { type FooterProps, query as footerQuery } from 'app/Footer'
 import PreviewButton from 'app/PreviewButton'
-import PreviewFooter from 'app/PreviewFooter'
-import PreviewTable from 'app/PreviewTable'
 import PreviewTemplate from 'app/PreviewTemplate'
 import ProductionTemplate from 'app/ProductionTemplate'
 import { createClient } from 'app/sanity.client'

--- a/app/sanity.preview.ts
+++ b/app/sanity.preview.ts
@@ -16,6 +16,7 @@ import { dataset, projectId } from './config'
 export const usePreview: UsePreview = _definePreview({
   projectId,
   dataset,
+  allowTypes: ['page'],
   importEventSourcePolyfill: () => use(lazyEventSourcePolyfill()),
   importGroqStore: () => use(lazyGroqStore()),
   checkAuth: (_projectId, token) => use(checkAuth(_projectId, token)),

--- a/app/sanity.preview.ts
+++ b/app/sanity.preview.ts
@@ -16,7 +16,7 @@ import { dataset, projectId } from './config'
 export const usePreview: UsePreview = _definePreview({
   projectId,
   dataset,
-  allowTypes: ['page'],
+  includeTypes: ['page'],
   importEventSourcePolyfill: () => use(lazyEventSourcePolyfill()),
   importGroqStore: () => use(lazyGroqStore()),
   checkAuth: (_projectId, token) => use(checkAuth(_projectId, token)),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sanity/preview-kit",
-  "version": "1.1.3",
+  "version": "1.2.0-add-type-allowlist.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/preview-kit",
-      "version": "1.1.3",
+      "version": "1.2.0-add-type-allowlist.1",
       "license": "MIT",
       "dependencies": {
         "@sanity/groq-store": "1.1.0-add-type-allowlist.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "@sanity/groq-store": "^1.0.4",
+        "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
         "@types/event-source-polyfill": "^1.0.0",
         "event-source-polyfill": "^1.0.31",
         "suspend-react": "^0.0.8"
@@ -2776,9 +2776,9 @@
       "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
     },
     "node_modules/@sanity/groq-store": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.0.4.tgz",
-      "integrity": "sha512-/VkUkTR3/xVIcFUrfxSm6NdPCgXg8MURNd8K7ftdRonNGh/rOZtTcvqj24mJueZhuoy+843himF3nOleMtuyrA==",
+      "version": "1.1.0-add-type-allowlist.1",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
+      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
       "dependencies": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",
@@ -14971,9 +14971,9 @@
       }
     },
     "@sanity/groq-store": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.0.4.tgz",
-      "integrity": "sha512-/VkUkTR3/xVIcFUrfxSm6NdPCgXg8MURNd8K7ftdRonNGh/rOZtTcvqj24mJueZhuoy+843himF3nOleMtuyrA==",
+      "version": "1.1.0-add-type-allowlist.1",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
+      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
       "requires": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@sanity/preview-kit",
-  "version": "1.2.0-add-type-allowlist.1",
+  "version": "1.2.0-add-type-allowlist.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sanity/preview-kit",
-      "version": "1.2.0-add-type-allowlist.1",
+      "version": "1.2.0-add-type-allowlist.2",
       "license": "MIT",
       "dependencies": {
-        "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
+        "@sanity/groq-store": "^1.1.0",
         "@types/event-source-polyfill": "^1.0.0",
         "event-source-polyfill": "^1.0.31",
-        "suspend-react": "^0.0.8"
+        "suspend-react": "0.0.8"
       },
       "devDependencies": {
         "@sanity/client": "^3.4.1",
@@ -2776,9 +2776,9 @@
       "integrity": "sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg=="
     },
     "node_modules/@sanity/groq-store": {
-      "version": "1.1.0-add-type-allowlist.1",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
-      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0.tgz",
+      "integrity": "sha512-D63l/5CvKe4SXbLEWj3+eV7WvQMj1udQA7SjO8WWnrowegS1bPN2T2dcoIexCJYlVSbWEmfFNaBkM3bdFcyEbA==",
       "dependencies": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",
@@ -14971,9 +14971,9 @@
       }
     },
     "@sanity/groq-store": {
-      "version": "1.1.0-add-type-allowlist.1",
-      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0-add-type-allowlist.1.tgz",
-      "integrity": "sha512-Nga7UQPhttFTxEHZnHIo7gvIVcl3x9W/Yo7PRxfOewZuwLUmypzOBdGjWYRHIvTtVAgA1+DGuxpopsoCn5DMXA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/groq-store/-/groq-store-1.1.0.tgz",
+      "integrity": "sha512-D63l/5CvKe4SXbLEWj3+eV7WvQMj1udQA7SjO8WWnrowegS1bPN2T2dcoIexCJYlVSbWEmfFNaBkM3bdFcyEbA==",
       "requires": {
         "@sanity/types": "^2.35.0",
         "eventsource": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
+    "@sanity/groq-store": "^1.1.0",
     "@types/event-source-polyfill": "^1.0.0",
     "event-source-polyfill": "^1.0.31",
-    "suspend-react": "^0.0.8"
+    "suspend-react": "0.0.8"
   },
   "devDependencies": {
     "@sanity/client": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/preview-kit",
-  "version": "1.2.0-add-type-allowlist.1",
+  "version": "1.2.0-add-type-allowlist.2",
   "description": "General purpose live previews, like next-sanity",
   "keywords": [
     "sanity",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "singleQuote": true
   },
   "dependencies": {
-    "@sanity/groq-store": "^1.0.4",
+    "@sanity/groq-store": "1.1.0-add-type-allowlist.1",
     "@types/event-source-polyfill": "^1.0.0",
     "event-source-polyfill": "^1.0.31",
     "suspend-react": "^0.0.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sanity/preview-kit",
-  "version": "1.1.3",
+  "version": "1.2.0-add-type-allowlist.1",
   "description": "General purpose live previews, like next-sanity",
   "keywords": [
     "sanity",

--- a/pages-extra/utils.ts
+++ b/pages-extra/utils.ts
@@ -6,6 +6,7 @@ let alerted = false
 export const usePreview: UsePreview = definePreview({
   projectId,
   dataset,
+  allowTypes: ['page'],
   onPublicAccessOnly: () => {
     if (!alerted) {
       // eslint-disable-next-line no-alert

--- a/pages-extra/utils.ts
+++ b/pages-extra/utils.ts
@@ -6,7 +6,7 @@ let alerted = false
 export const usePreview: UsePreview = definePreview({
   projectId,
   dataset,
-  allowTypes: ['page'],
+  includeTypes: ['page'],
   onPublicAccessOnly: () => {
     if (!alerted) {
       // eslint-disable-next-line no-alert

--- a/src/definePreview.ts
+++ b/src/definePreview.ts
@@ -74,7 +74,7 @@ export const _definePreview = ({
   preload,
   onPublicAccessOnly,
   checkAuth,
-  allowTypes,
+  includeTypes,
 }: _PreviewConfig): UsePreview => {
   if (!projectId) {
     console.warn(`No projectId set for createPreviewHook, returning dummy hook`)
@@ -132,7 +132,7 @@ export const _definePreview = ({
         dataset,
         documentLimit,
         subscriptionThrottleMs,
-        allowTypes,
+        includeTypes,
         token: token === null ? undefined : token,
         // Lazy load the huge `event-source-polyfill`, but only if a token is specified
         EventSource: token === null ? undefined : importEventSourcePolyfill(),
@@ -194,7 +194,7 @@ export interface PreviewConfig
     | 'dataset'
     | 'documentLimit'
     | 'subscriptionThrottleMs'
-    | 'allowTypes'
+    | 'includeTypes'
   > {
   /**
    * You want to throw an error in this function if it's considered a failure if draft documents can't be queried.

--- a/src/definePreview.ts
+++ b/src/definePreview.ts
@@ -188,7 +188,11 @@ export type UsePreview<R = any, P = Params, Q = string> = (
 export interface PreviewConfig
   extends Pick<
     Config,
-    'projectId' | 'dataset' | 'documentLimit' | 'subscriptionThrottleMs'
+    | 'projectId'
+    | 'dataset'
+    | 'documentLimit'
+    | 'subscriptionThrottleMs'
+    | 'allowTypes'
   > {
   /**
    * You want to throw an error in this function if it's considered a failure if draft documents can't be queried.

--- a/src/definePreview.ts
+++ b/src/definePreview.ts
@@ -74,6 +74,7 @@ export const _definePreview = ({
   preload,
   onPublicAccessOnly,
   checkAuth,
+  allowTypes,
 }: _PreviewConfig): UsePreview => {
   if (!projectId) {
     console.warn(`No projectId set for createPreviewHook, returning dummy hook`)
@@ -131,6 +132,7 @@ export const _definePreview = ({
         dataset,
         documentLimit,
         subscriptionThrottleMs,
+        allowTypes,
         token: token === null ? undefined : token,
         // Lazy load the huge `event-source-polyfill`, but only if a token is specified
         EventSource: token === null ? undefined : importEventSourcePolyfill(),


### PR DESCRIPTION
Exposes the `allowTypes` option that's introduced in a prerelease of `@sanity/groq-store`: https://github.com/sanity-io/groq-store/pull/2

Install it using `npm i --save-exact @sanity/preview-kit@add-type-allowlist`.
And in `definePreview` you can now set the `allowTypes` option:

```tsx
import {definePreview} from '@sanity/preview-kit'
const usePreview = definePreview({
  /* ... */
  allowTypes: ['post', 'author', 'sanity.imageAsset'],
})
```

To quickly list types in a dataset run this groq query in `@sanity/vision`, with the `apiVersion` set to `vX`:
```groq
array::unique(*._type)
```