### PR TITLE
fix(build): include `node` directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
+    "node",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
Include the `node` directory in the npm distribution.