### PR TITLE
fix(build): auto-generate Node ESM wrapper

### DIFF
--- a/node/index.js
+++ b/node/index.js
@@ -1,8 +1,0 @@
-import cjs from '../dist/index.cjs'
-
-export const PreviewSuspense = cjs.PreviewSuspense
-export const _checkAuth = cjs._checkAuth
-export const _definePreview = cjs._definePreview
-export const _lazyEventSourcePolyfill = cjs._lazyEventSourcePolyfill
-export const _lazyGroqStore = cjs._lazyGroqStore
-export const definePreview = cjs.definePreview

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@remix-run/eslint-config": "^1.9.0",
         "@sanity/client": "^3.4.1",
         "@sanity/eslint-config-studio": "^2.0.1",
-        "@sanity/pkg-utils": "^2.0.7",
+        "@sanity/pkg-utils": "^2.1.0",
         "@sanity/semantic-release-preset": "^2.0.5",
         "@types/node": "^18.11.18",
         "@types/react": "^18.0.26",
@@ -3280,9 +3280,9 @@
       }
     },
     "node_modules/@sanity/pkg-utils": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-2.0.7.tgz",
-      "integrity": "sha512-S13KSh8F4oB2/3/ml+rMkcj5zOAn1wPp6aUoMx3viiZfcS4K4iJ85r4N0ltqyRZxGdr9fDpKol5yWKQS/zktjw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sanity/pkg-utils/-/pkg-utils-2.1.0.tgz",
+      "integrity": "sha512-CY6quDkMZRnCrkvT44NuP1dTo/GvNQ4R3C6NQ0NhnTjSimGdYMim9Ub7URX2M3B/2ATEyd1PLEJTHAXECSdmeA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.20.7",
@@ -7995,8 +7995,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -8279,7 +8278,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -12111,7 +12109,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },

--- a/package.config.ts
+++ b/package.config.ts
@@ -13,4 +13,6 @@ export default defineConfig({
       },
     ],
   },
+
+  tsconfig: 'tsconfig.build.json',
 })

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": {
-        "import": "./node/index.js",
-        "require": "./dist/index.cjs"
-      },
       "source": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs",
+      "node": {
+        "import": "./dist/index.cjs.js",
+        "require": "./dist/index.cjs"
+      },
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json"
@@ -45,12 +45,11 @@
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
-    "node",
     "src"
   ],
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "pkg build --tsconfig tsconfig.build.json --strict",
+    "build": "pkg build --strict && pkg --strict",
     "clean": "rimraf dist",
     "dev": "next",
     "format": "npm run prettier && eslint --cache --fix .",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@remix-run/eslint-config": "^1.9.0",
     "@sanity/client": "^3.4.1",
     "@sanity/eslint-config-studio": "^2.0.1",
-    "@sanity/pkg-utils": "^2.0.7",
+    "@sanity/pkg-utils": "^2.1.0",
     "@sanity/semantic-release-preset": "^2.0.5",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.26",


### PR DESCRIPTION
Since `@sanity/pkg-utils@2.1.0` we can auto-generate the Node ESM wrapper which re-exports from the CommonJS export. This mode is enabled by adding a `node.import` with either a `.cjs.js` or `.cjs.mjs` extension like so:

```json5
  "type": "module",
  "exports": {
    ".": {
      // ...
      "node": {
        "import": "./dist/index.cjs.js", // this file will be generated
        "require": "./dist/index.cjs" // this is the source CommonJS file
      }
    }
  }
```