### PR TITLE
feat: add `useListeningQueryStatus` hook

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -326,7 +326,7 @@ export default function CountPage() {
           dataset={dataset}
           token={preview.token}
         >
-          <PreviewCount />
+          <Count data={data} />
         </GroqStoreProvider>
       ) : (
         <Count data={data} />
@@ -335,20 +335,18 @@ export default function CountPage() {
   )
 }
 
-const Count = ({ data }: { data: number }) => (
-  <>
-    Documents: <strong>{data}</strong>
-  </>
-)
+const Count = ({ data: serverSnapshot }: { data: number | null }) => {
+  const data = useListeningQuery(serverSnapshot, query)
+  const isLoading = useListeningQueryStatus(query) === 'loading'
 
-const isLoadingCount = Symbol('isLoadingCount')
-const PreviewCount = () => {
-  const snapshot = useListeningQuery(isLoadingCount, query)
-
-  if (snapshot === isLoadingCount) {
+  if (isLoading) {
     return <Spinner />
   }
 
-  return <Count data={snapshot} />
+  return (
+    <>
+      Documents: <strong>{data}</strong>
+    </>
+  )
 }
 ```

--- a/apps/next-app-router-groq-store/app/PreviewProvider.tsx
+++ b/apps/next-app-router-groq-store/app/PreviewProvider.tsx
@@ -11,7 +11,12 @@ export default function PreviewProvider({
   token: string
 }) {
   return (
-    <GroqStoreProvider projectId={projectId} dataset={dataset} token={token}>
+    <GroqStoreProvider
+      projectId={projectId}
+      dataset={dataset}
+      token={token}
+      documentLimit={Infinity}
+    >
       {children}
     </GroqStoreProvider>
   )

--- a/apps/next-app-router-groq-store/app/ViewPublishedButtonWithLoadingStatus.tsx
+++ b/apps/next-app-router-groq-store/app/ViewPublishedButtonWithLoadingStatus.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { tableQuery } from 'ui/react'
+import { ViewPublishedButton } from 'ui/react'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
+
+export default function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
+}

--- a/apps/next-app-router-groq-store/app/page.tsx
+++ b/apps/next-app-router-groq-store/app/page.tsx
@@ -1,10 +1,5 @@
 import { draftMode } from 'next/headers'
-import {
-  ViewPublishedButton,
-  PreviewDraftsButton,
-  Footer,
-  footerQuery,
-} from 'ui/react'
+import { PreviewDraftsButton, Footer, footerQuery } from 'ui/react'
 import RefreshButton from './RefreshButton'
 import { unstable__adapter, unstable__environment } from '@sanity/client'
 import { Table, Timestamp, tableQuery } from 'ui/react'
@@ -12,24 +7,30 @@ import { sanityClient, draftsClient } from './sanity.client'
 import PreviewProvider from './PreviewProvider'
 import PreviewTable from './PreviewTable'
 import PreviewFooter from './PreviewFooter'
+import ViewPublishedButtonWithLoadingStatus from './ViewPublishedButtonWithLoadingStatus'
 
 export default async function Page() {
   const isDraftMode = draftMode().isEnabled
-  const button = isDraftMode ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = isDraftMode ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const client = isDraftMode ? draftsClient : sanityClient
   const table = client.fetch(tableQuery)
   const footer = client.fetch(footerQuery)
   return (
     <>
       <form action="/api/draft" style={{ display: 'contents' }}>
-        {button}
         {isDraftMode ? (
           <PreviewProvider token={client.config().token!}>
+            {button}
             <PreviewTable data={await table} />
             <PreviewFooter data={await footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={await table} />
             <Footer data={await footer} />
           </>

--- a/apps/next-app-router-live-store/app/ViewPublishedButtonWithLoadingStatus.tsx
+++ b/apps/next-app-router-live-store/app/ViewPublishedButtonWithLoadingStatus.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { tableQuery } from 'ui/react'
+import { ViewPublishedButton } from 'ui/react'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
+
+export default function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
+}

--- a/apps/next-app-router-live-store/app/page.tsx
+++ b/apps/next-app-router-live-store/app/page.tsx
@@ -12,6 +12,7 @@ import { sanityClient, draftsClient } from './sanity.client'
 import PreviewProvider from './PreviewProvider'
 import PreviewTable from './PreviewTable'
 import PreviewFooter from './PreviewFooter'
+import ViewPublishedButtonWithLoadingStatus from './ViewPublishedButtonWithLoadingStatus'
 
 const token = process.env.SANITY_API_READ_TOKEN
 if (!token) {
@@ -20,21 +21,26 @@ if (!token) {
 
 export default async function Page() {
   const isDraftMode = draftMode().isEnabled
-  const button = isDraftMode ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = isDraftMode ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const client = isDraftMode ? draftsClient.withConfig({ token }) : sanityClient
   const table = client.fetch(tableQuery)
   const footer = client.fetch(footerQuery)
   return (
     <>
       <form action="/api/draft" style={{ display: 'contents' }}>
-        {button}
         {isDraftMode ? (
           <PreviewProvider token={client.config().token!}>
+            {button}
             <PreviewTable data={await table} />
             <PreviewFooter data={await footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={await table} />
             <Footer data={await footer} />
           </>

--- a/apps/next-app-router-no-store/app/ViewPublishedButtonWithLoadingStatus.tsx
+++ b/apps/next-app-router-no-store/app/ViewPublishedButtonWithLoadingStatus.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import { tableQuery } from 'ui/react'
+import { ViewPublishedButton } from 'ui/react'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
+
+export default function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
+}

--- a/apps/next-app-router-no-store/app/page.tsx
+++ b/apps/next-app-router-no-store/app/page.tsx
@@ -1,20 +1,20 @@
 import { draftMode } from 'next/headers'
-import {
-  ViewPublishedButton,
-  PreviewDraftsButton,
-  Footer,
-  footerQuery,
-} from 'ui/react'
+import { PreviewDraftsButton, Footer, footerQuery } from 'ui/react'
 import RefreshButton from './RefreshButton'
 import { unstable__adapter, unstable__environment } from '@sanity/client'
 import { Table, Timestamp, tableQuery } from 'ui/react'
 import { sanityClient, draftsClient } from './sanity.client'
 import PreviewTable from './PreviewTable'
 import PreviewFooter from './PreviewFooter'
+import ViewPublishedButtonWithLoadingStatus from './ViewPublishedButtonWithLoadingStatus'
 
 export default async function Page() {
   const isDraftMode = draftMode().isEnabled
-  const button = isDraftMode ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = isDraftMode ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const client = isDraftMode ? draftsClient : sanityClient
   const table = client.fetch(tableQuery)
   const footer = client.fetch(footerQuery)

--- a/apps/next-pages-router-groq-store/src/PreviewProvider.tsx
+++ b/apps/next-pages-router-groq-store/src/PreviewProvider.tsx
@@ -9,7 +9,12 @@ export default function PreviewProvider({
   token: string
 }) {
   return (
-    <GroqStoreProvider projectId={projectId} dataset={dataset} token={token}>
+    <GroqStoreProvider
+      projectId={projectId}
+      dataset={dataset}
+      token={token}
+      documentLimit={Infinity}
+    >
       {children}
     </GroqStoreProvider>
   )

--- a/apps/next-pages-router-groq-store/src/pages/index.tsx
+++ b/apps/next-pages-router-groq-store/src/pages/index.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react'
 import { lazy } from 'react'
 import Table from '../Table'
 import Footer from '../Footer'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 const PreviewProvider = lazy(() => import('../PreviewProvider'))
 
@@ -73,7 +74,11 @@ export default function Page({
   server__adapter,
   server__environment,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   useEffect(() => {
@@ -86,14 +91,15 @@ export default function Page({
   return (
     <Container>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <PreviewProvider token={token!}>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -117,4 +123,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/apps/next-pages-router-live-store/src/pages/index.tsx
+++ b/apps/next-pages-router-live-store/src/pages/index.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react'
 import { lazy } from 'react'
 import Table from '../Table'
 import Footer from '../Footer'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 const PreviewProvider = lazy(() => import('../PreviewProvider'))
 
@@ -67,7 +68,11 @@ export default function Page({
   server__adapter,
   server__environment,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   useEffect(() => {
@@ -80,14 +85,15 @@ export default function Page({
   return (
     <Container>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <PreviewProvider token={token!}>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -111,4 +117,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/apps/remix-groq-store-lazy/app/PreviewProvider.tsx
+++ b/apps/remix-groq-store-lazy/app/PreviewProvider.tsx
@@ -13,7 +13,12 @@ export default function PreviewProvider({
   token: string
 } & Pick<GroqStoreProviderProps, 'projectId' | 'dataset'>) {
   return (
-    <GroqStoreProvider projectId={projectId} dataset={dataset} token={token}>
+    <GroqStoreProvider
+      projectId={projectId}
+      dataset={dataset}
+      token={token}
+      documentLimit={Infinity}
+    >
       {children}
     </GroqStoreProvider>
   )

--- a/apps/remix-groq-store-lazy/app/routes/index.tsx
+++ b/apps/remix-groq-store-lazy/app/routes/index.tsx
@@ -20,6 +20,7 @@ import { getSession } from '~/sessions'
 import { useEffect, lazy, Suspense } from 'react'
 import Footer from '~/Footer'
 import Table from '~/Table'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 const projectId = process.env.SANITY_PROJECT_ID || 'pv8y60vp'
 const dataset = process.env.SANITY_DATASET || 'production'
@@ -92,18 +93,22 @@ export default function Index() {
     })
   }, [])
 
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   return (
     <>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <Suspense
             fallback={
               <>
-                <TableFallback rows={table.length} />
+                {button}
+                <TableFallback rows={(table as any).length} />
                 <Footer data={footer} />
               </>
             }
@@ -113,12 +118,14 @@ export default function Index() {
               projectId={projectId}
               dataset={dataset}
             >
+              {button}
               <Table data={table} />
               <Footer data={footer} />
             </PreviewProvider>
           </Suspense>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -150,4 +157,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/apps/remix-groq-store/app/PreviewProvider.tsx
+++ b/apps/remix-groq-store/app/PreviewProvider.tsx
@@ -13,7 +13,12 @@ export default function PreviewProvider({
   token: string
 } & Pick<GroqStoreProviderProps, 'projectId' | 'dataset'>) {
   return (
-    <GroqStoreProvider projectId={projectId} dataset={dataset} token={token}>
+    <GroqStoreProvider
+      projectId={projectId}
+      dataset={dataset}
+      token={token}
+      documentLimit={Infinity}
+    >
       {children}
     </GroqStoreProvider>
   )

--- a/apps/remix-groq-store/app/routes/index.tsx
+++ b/apps/remix-groq-store/app/routes/index.tsx
@@ -20,6 +20,7 @@ import { useEffect } from 'react'
 import Footer from '~/Footer'
 import Table from '~/Table'
 import PreviewProvider from '~/PreviewProvider'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 const projectId = process.env.SANITY_PROJECT_ID || 'pv8y60vp'
 const dataset = process.env.SANITY_DATASET || 'production'
@@ -90,24 +91,29 @@ export default function Index() {
     })
   }, [])
 
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   return (
     <>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <PreviewProvider
             token={token!}
             projectId={projectId}
             dataset={dataset}
           >
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -139,4 +145,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/apps/remix-live-store-lazy/app/routes/index.tsx
+++ b/apps/remix-live-store-lazy/app/routes/index.tsx
@@ -20,6 +20,7 @@ import { Suspense, lazy, useEffect } from 'react'
 import { getClient } from '~/utils'
 import Footer from '~/Footer'
 import Table from '~/Table'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 const PreviewProvider = lazy(() => import('../PreviewProvider'))
 
@@ -84,22 +85,27 @@ export default function Index() {
     })
   }, [])
 
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   return (
     <>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <Suspense
             fallback={
               <>
-                <TableFallback rows={table.length} />
+                {button}
+                <TableFallback rows={(table as any).length} />
                 <Footer data={footer} />
               </>
             }
           >
+            {button}
             <PreviewProvider
               apiVersion={apiVersion}
               useCdn={useCdn}
@@ -113,6 +119,7 @@ export default function Index() {
           </Suspense>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -144,4 +151,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/apps/remix-live-store/app/routes/index.tsx
+++ b/apps/remix-live-store/app/routes/index.tsx
@@ -20,6 +20,7 @@ import { getClient } from '~/utils'
 import PreviewProvider from '~/PreviewProvider'
 import Table from '~/Table'
 import Footer from '~/Footer'
+import { useListeningQueryStatus } from '@sanity/preview-kit'
 
 export async function loader({ request }: LoaderArgs) {
   const session = await getSession(request.headers.get('Cookie'))
@@ -82,13 +83,16 @@ export default function Index() {
     })
   }, [])
 
-  const button = preview ? <ViewPublishedButton /> : <PreviewDraftsButton />
+  const button = preview ? (
+    <ViewPublishedButtonWithLoadingStatus />
+  ) : (
+    <PreviewDraftsButton />
+  )
   const action = preview ? '/api/exit-preview' : '/api/preview'
 
   return (
     <>
       <form action={action} style={{ display: 'contents' }}>
-        {button}
         {preview ? (
           <PreviewProvider
             apiVersion={apiVersion}
@@ -97,11 +101,13 @@ export default function Index() {
             projectId={projectId}
             dataset={dataset}
           >
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </PreviewProvider>
         ) : (
           <>
+            {button}
             <Table data={table} />
             <Footer data={footer} />
           </>
@@ -133,4 +139,10 @@ function RefreshButton() {
       <Button>Refresh</Button>
     </form>
   )
+}
+
+function ViewPublishedButtonWithLoadingStatus() {
+  const status = useListeningQueryStatus(tableQuery)
+
+  return <ViewPublishedButton isLoading={status === 'loading'} />
 }

--- a/packages/preview-kit/README.md
+++ b/packages/preview-kit/README.md
@@ -521,9 +521,9 @@ export function UsersList(props: UsersListProps) {
 
 And done! You can optionally optimize it further by adding a loading UI while it loads, or improve performance by adding a custom `isEqual` function to reduce React re-renders if there's a lot of data that changes but isn't user visible (SEO metadata and such).
 
-#### Implementing a Loading UI
+#### Implementing a Loading UI with `useListeningQueryStatus`
 
-The best way to do this is to add a wrapper component that is only used in preview mode that calls the `useListeningQuery` hook, this allows you to use the `initialSnapshot` to determine if the previews are finished loading or not.
+The best way to do this is to add a wrapper component that is only used in preview mode that calls the `useListeningQuery` and `useListeningQueryStatus` hooks.
 
 ```tsx
 export function UsersList(props: UsersListProps) {
@@ -537,16 +537,14 @@ export function UsersList(props: UsersListProps) {
   )
 }
 
-const isLoadingSymbol = Symbol('isLoading')
 export function PreviewUsersList(props: UsersListProps) {
   const { data: serverSnapshot, lastId } = props
-  const snapshot = useListeningQuery(isLoadingSymbol, usersQuery, { lastId })
-  const isLoading = snapshot === isLoadingSymbol
-  const data = isLoading ? serverSnapshot : snapshot
+  const data = useListeningQuery(serverSnapshot, usersQuery, { lastId })
+  const queryStatus = useListeningQueryStatus(usersQuery, { lastId })
 
   return (
     <>
-      <PreviewStatus isLoading={isLoading} />
+      <PreviewStatus isLoading={queryStatus === 'loading'} />
       <UsersList data={users} lastId={lastId} />
     </>
   )

--- a/packages/preview-kit/src/context.ts
+++ b/packages/preview-kit/src/context.ts
@@ -2,9 +2,18 @@ import { createContext } from 'react'
 
 import { NoStoreContext } from './no-store'
 import { DefineListenerContext } from './types'
+import { QueryCacheKey } from './utils'
 
 /**
  * @internal
  */
 export const defineListenerContext =
   createContext<DefineListenerContext>(NoStoreContext)
+
+/**
+ * If it's `null` then the listener should be treated as `success`, otherwise if a listener isn't in the array it should be considered as `loading`
+ * @internal
+ */
+export const LoadedListenersContext = createContext<QueryCacheKey[] | null>(
+  null
+)

--- a/packages/preview-kit/src/types.ts
+++ b/packages/preview-kit/src/types.ts
@@ -21,3 +21,8 @@ export type DefineListenerContext = <QueryResult>(
   subscribe: ListenerSubscribe
   getSnapshot: ListenerGetSnapshot<QueryResult>
 }
+
+/**
+ * @public
+ */
+export type ListenerStatus = 'loading' | 'success'

--- a/packages/ui/src/react/components.tsx
+++ b/packages/ui/src/react/components.tsx
@@ -113,9 +113,18 @@ import { memo } from 'react'
 //   )
 // })
 
-export function Button({ children }: { children: React.ReactNode }) {
+export function Button({
+  children,
+  isLoading,
+}: {
+  children: React.ReactNode
+  isLoading?: boolean
+}) {
   return (
-    <button type="submit" className={`button is-light `}>
+    <button
+      type="submit"
+      className={`button is-light ${isLoading ? 'is-loading' : ''}`}
+    >
       {children}
     </button>
   )
@@ -128,10 +137,10 @@ export function PreviewDraftsButton() {
   )
 }
 
-export function ViewPublishedButton() {
+export function ViewPublishedButton({ isLoading }: { isLoading?: boolean }) {
   return (
     <section className="section">
-      <Button>View Published</Button>
+      <Button isLoading={isLoading}>View Published</Button>
     </section>
   )
 }


### PR DESCRIPTION
The `useListeningQueryStatus` hook can be used to show loading UI while the live preview experience is booting up:


https://github.com/sanity-io/preview-kit/assets/81981/089a895e-54a1-4420-9fa4-d1ad0c078d3e

