### PR TITLE
chore: backwards compatibility for `mapToEditLinks`

### DIFF
--- a/packages/preview-kit/src/client/index.ts
+++ b/packages/preview-kit/src/client/index.ts
@@ -1,2 +1,5 @@
 export * from './createClient'
 export type * from './types'
+
+// To keep backwards compatibility with the old `mapToEditLinks` function
+export * from './mapToEditLinks'

--- a/packages/preview-kit/src/client/mapToEditLinks.ts
+++ b/packages/preview-kit/src/client/mapToEditLinks.ts
@@ -1,0 +1,17 @@
+import { mapToEditLinks as CSMMapToEditLinks } from '../csm/mapToEditLinks'
+import type { ContentSourceMapQueryResponse } from './types'
+
+/**
+ * @deprecated Please use `mapToEditLinks` from `@sanity/preview-kit/csm` instead
+ * @alpha
+ */
+export function mapToEditLinks(
+  response: ContentSourceMapQueryResponse,
+  studioUrl: string,
+): unknown {
+  return CSMMapToEditLinks(
+    response.result,
+    response.resultSourceMap!,
+    studioUrl,
+  )
+}


### PR DESCRIPTION
Keep backwards compatibility for `mapToEditLinks` and marks it as deprecated.