### PR TITLE
feat(csm): support _key array filter selectors

### DIFF
--- a/packages/preview-kit/src/LiveStoreProvider/LiveStoreProvider.tsx
+++ b/packages/preview-kit/src/LiveStoreProvider/LiveStoreProvider.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react'
 
 import { defineListenerContext as Context, IsEnabledContext } from '../context'
-import { parseNormalisedJsonPath } from '../csm/jsonpath'
+import { parseJsonPath } from '../csm/jsonpath'
 import { resolveMapping, walkMap } from '../csm/sourcemap'
 import type {
   DefineListenerContext,
@@ -679,7 +679,7 @@ function turboChargeResultIfSourceMap(
       const cachedValue = cachedDocument
         ? get(
             cachedDocument,
-            parseNormalisedJsonPath(sourcePath + pathSuffix),
+            parseJsonPath(sourcePath + pathSuffix),
             value,
           )
         : value

--- a/packages/preview-kit/src/csm/editIntent.ts
+++ b/packages/preview-kit/src/csm/editIntent.ts
@@ -3,7 +3,7 @@ import {
   ContentSourceMapDocuments,
 } from '@sanity/client'
 
-import { parseNormalisedJsonPath } from './jsonpath'
+import { parseJsonPath } from './jsonpath'
 import type { PathSegment, StudioUrl } from './types'
 
 /** @alpha */
@@ -40,7 +40,7 @@ export function defineEditLink(
 export function encodeJsonPathToUriComponent(
   path: string | PathSegment[],
 ): string {
-  const sourcePath = Array.isArray(path) ? path : parseNormalisedJsonPath(path)
+  const sourcePath = Array.isArray(path) ? path : parseJsonPath(path)
   return encodeURIComponent(
     sourcePath
       .map((key, i) =>

--- a/packages/preview-kit/src/csm/jsonpath.test.ts
+++ b/packages/preview-kit/src/csm/jsonpath.test.ts
@@ -1,21 +1,21 @@
 import { expect, test } from 'vitest'
 
-import { normalisedJsonPath, parseNormalisedJsonPath } from './jsonpath'
+import { jsonPath, parseJsonPath } from './jsonpath'
 
 test('formats normalised JSON Paths', () => {
-  expect(normalisedJsonPath(['foo', 'bar', 0, 'baz'])).toBe(
+  expect(jsonPath(['foo', 'bar', 0, 'baz'])).toBe(
     "$['foo']['bar'][0]['baz']",
   )
 })
 
 test('formats normalised JSON Paths with escaped characters', () => {
-  expect(normalisedJsonPath(['foo', 'bar', 0, 'baz', "it's a 'test'"])).toBe(
+  expect(jsonPath(['foo', 'bar', 0, 'baz', "it's a 'test'"])).toBe(
     "$['foo']['bar'][0]['baz']['it\\'s a \\'test\\'']",
   )
 })
 
 test('parses normalised JSON Paths', () => {
-  expect(parseNormalisedJsonPath("$['foo']['bar'][0]['baz']")).toEqual([
+  expect(parseJsonPath("$['foo']['bar'][0]['baz']")).toEqual([
     'foo',
     'bar',
     0,
@@ -25,6 +25,16 @@ test('parses normalised JSON Paths', () => {
 
 test('parses normalised JSON Paths with escaped characters', () => {
   expect(
-    parseNormalisedJsonPath("$['foo']['bar'][0]['baz']['it\\'s a \\'test\\'']"),
+    parseJsonPath("$['foo']['bar'][0]['baz']['it\\'s a \\'test\\'']"),
   ).toEqual(['foo', 'bar', 0, 'baz', "it's a 'test'"])
+})
+
+test('parses normalised JSON Paths with key array filter selectors', () => {
+  expect(parseJsonPath("$['foo'][?(@._key=='section-1')][0]['baz'][?(@._key=='section-2')]")).toEqual([
+    'foo',
+    { key: 'section-1', index: -1 },
+    0,
+    'baz',
+    { key: 'section-2', index: -1},
+  ])
 })

--- a/packages/preview-kit/src/csm/sourcemap.test.ts
+++ b/packages/preview-kit/src/csm/sourcemap.test.ts
@@ -9,6 +9,9 @@ const encodeTestCases: {
     result: unknown
     resultSourceMap: ContentSourceMap
   }
+  options?: {
+    keyArraySelectors: boolean
+  },
   expected: {
     encoderCalls: number
     encoderArgs: unknown[][]
@@ -92,11 +95,119 @@ const encodeTestCases: {
       ],
     },
   },
+  {
+    name: 'plucks out _key to use as path segment',
+    queryResult: {
+      result: [
+        {
+          _id: 'foo',
+          nested: {
+            arr: [
+              {
+                _key: 'im_a_key',
+                value: 'that',
+              },
+            ]
+          },
+        },
+      ],
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ["$['projected']['nested']"],
+        mappings: {
+          "$[0]['nested']": {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    options: {
+      keyArraySelectors: true,
+    },
+    expected: {
+      encoderCalls: 2,
+      encoderArgs: [
+        [
+          'im_a_key',
+          { _id: 'foo', _type: 'bar' },
+          ['projected', 'nested', 'arr', { key: 'im_a_key', index: 0 }, '_key']
+        ],
+        [
+          'that',
+          { _id: 'foo', _type: 'bar' },
+          ['projected', 'nested', 'arr', { key: 'im_a_key', index: 0 }, 'value']
+        ],
+      ],
+    },
+  },
+  {
+    name: 'handles _key array filter selectors in source paths',
+    queryResult: {
+      result: [
+        {
+          _id: 'foo',
+          arr: [
+            {
+              _key: 'im_a_key',
+              value: 'that',
+            },
+          ]
+        },
+      ],
+      resultSourceMap: {
+        documents: [
+          {
+            _id: 'foo',
+            _type: 'bar',
+          },
+        ],
+        paths: ["$['projected'][?(@._key=='fooKey')]"],
+        mappings: {
+          "$[0]['arr']": {
+            source: {
+              document: 0,
+              path: 0,
+              type: 'documentValue',
+            },
+            type: 'value',
+          },
+        },
+      },
+    },
+    options: {
+      keyArraySelectors: true,
+    },
+    expected: {
+      encoderCalls: 2,
+      encoderArgs: [
+        [
+          'im_a_key',
+          { _id: 'foo', _type: 'bar' },
+          ['projected', { key: 'fooKey', index: -1 }, { key: 'im_a_key', index: 0 }, '_key']
+        ],
+        [
+          'that',
+          { _id: 'foo', _type: 'bar' },
+          ['projected', { key: 'fooKey', index: -1 }, { key: 'im_a_key', index: 0 }, 'value']
+        ],
+      ],
+    },
+  },
 ]
 
-test.each(encodeTestCases)('encode $name', ({ queryResult, expected }) => {
+test.each(encodeTestCases)('encode $name', ({ queryResult, options, expected }) => {
   const mockTranscoder = vi.fn().mockImplementation((input: string) => input)
-  encode(queryResult.result, queryResult.resultSourceMap, mockTranscoder)
+  encode(queryResult.result, queryResult.resultSourceMap, mockTranscoder, options)
 
   expect(mockTranscoder).toBeCalledTimes(expected.encoderCalls)
   for (const args of expected.encoderArgs) {

--- a/packages/preview-kit/src/csm/types.ts
+++ b/packages/preview-kit/src/csm/types.ts
@@ -38,7 +38,10 @@ export interface CreateTranscoderConfig {
 }
 
 /** @public */
-export type PathSegment = string | number
+export type PathSegment = string | number | KeyedSegment
+
+/** @public */
+export type KeyedSegment = { key: string; index: number }
 
 /** @public */
 export type StudioUrl =


### PR DESCRIPTION
### Draft implementation

When `keyArraySelectors` mode is enabled, this will now return source paths with keyed array filter selectors e.g. `[?(@._key=='section-1')]`

Todo:
- `keyArraySelectors` mode needs enabling through an option/config and thread through

Questions:

- `FilterDefault` depends on array index paths, should this also support _key?
- `encodeJsonPathToUriComponent` - does this need to change to support studio deep links with _key selector?
- `LiveStoreProvider` is depending on `resolveMapping` in the current implementation it wont support _key selectors
