### PR TITLE
feat: support client perspectives

### DIFF
--- a/apps/next-app-router/app/sanity.fetch.ts
+++ b/apps/next-app-router/app/sanity.fetch.ts
@@ -3,6 +3,7 @@ import 'server-only'
 import type {QueryParams} from '@sanity/client'
 import {client} from './sanity.client'
 import {draftMode} from 'next/headers'
+import {getPerspective} from './sanity.perspective'
 
 export const token = process.env.SANITY_API_READ_TOKEN || ''
 
@@ -26,7 +27,7 @@ export async function sanityFetch<QueryResponse>({
   return client.fetch<QueryResponse>(query, params, {
     ...(isDraftMode && {
       token,
-      perspective: 'previewDrafts',
+      perspective: await getPerspective(),
     }),
     next: {
       revalidate: isDraftMode ? 0 : false,

--- a/apps/next-app-router/app/sanity.perspective.ts
+++ b/apps/next-app-router/app/sanity.perspective.ts
@@ -1,0 +1,19 @@
+import type {ClientPerspective} from 'next-sanity'
+import {cookies, draftMode} from 'next/headers'
+
+export async function getPerspective() {
+  const {isEnabled} = await draftMode()
+  let perspective: Exclude<ClientPerspective, 'raw'> = 'previewDrafts'
+  if (isEnabled) {
+    const cookieStore = await cookies()
+    if (cookieStore.has('sanity-preview-perspective')) {
+      const cookie = cookieStore.get('sanity-preview-perspective')
+      if (cookie!.value.includes(',')) {
+        perspective = cookie!.value.split(',') as unknown as Exclude<ClientPerspective, 'raw'>
+      } else {
+        perspective = cookie!.value as unknown as Exclude<ClientPerspective, 'raw'>
+      }
+    }
+  }
+  return perspective
+}

--- a/apps/next-app-router/app/variants/live-store/PreviewProvider.tsx
+++ b/apps/next-app-router/app/variants/live-store/PreviewProvider.tsx
@@ -2,17 +2,20 @@
 
 import {LiveQueryProvider} from '@sanity/preview-kit'
 import {client} from './sanity.client'
+import type {ClientPerspective} from 'next-sanity'
 
 export default function PreviewProvider({
   children,
   token,
+  perspective,
 }: {
   children: React.ReactNode
   token: string
+  perspective: Exclude<ClientPerspective, 'raw'>
 }) {
   if (!token) throw new TypeError('Missing token')
   return (
-    <LiveQueryProvider client={client} token={token} logger={console}>
+    <LiveQueryProvider client={client} token={token} logger={console} perspective={perspective}>
       {children}
     </LiveQueryProvider>
   )

--- a/apps/next-app-router/app/variants/live-store/index.tsx
+++ b/apps/next-app-router/app/variants/live-store/index.tsx
@@ -1,17 +1,22 @@
-import {draftMode} from 'next/headers'
+import {draftMode, cookies} from 'next/headers'
 import dynamic from 'next/dynamic'
-import {VisualEditing} from 'next-sanity'
+import {VisualEditing, type ClientPerspective} from 'next-sanity'
 import {token} from '../../sanity.fetch'
+import {getPerspective} from '../../sanity.perspective'
 
 const PreviewProvider = dynamic(() => import('./PreviewProvider'))
 
 export default async function LiveStoreVariant({children}: React.PropsWithChildren) {
   const {isEnabled} = await draftMode()
+  const perspective = await getPerspective()
+
   return (
     <>
       {isEnabled ? (
         <>
-          <PreviewProvider token={token}>{children}</PreviewProvider>
+          <PreviewProvider token={token} perspective={perspective}>
+            {children}
+          </PreviewProvider>
           <VisualEditing />
         </>
       ) : (

--- a/apps/next-app-router/package.json
+++ b/apps/next-app-router/package.json
@@ -18,7 +18,7 @@
     "groq": "3.71.1",
     "groqd": "0.15.12",
     "next": "15.1.6",
-    "next-sanity": "9.8.40",
+    "next-sanity": "9.8.41",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "server-only": "^0.0.1",

--- a/apps/next-pages-router/package.json
+++ b/apps/next-pages-router/package.json
@@ -19,7 +19,7 @@
     "groq": "3.71.1",
     "groqd": "0.15.12",
     "next": "15.1.6",
-    "next-sanity": "9.8.40",
+    "next-sanity": "9.8.41",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "ui": "workspace:*"

--- a/apps/next-pages-router/src/variants/live-store/PreviewProvider.tsx
+++ b/apps/next-pages-router/src/variants/live-store/PreviewProvider.tsx
@@ -1,5 +1,8 @@
 import {LiveQueryProvider} from '@sanity/preview-kit'
 import {client} from './sanity.client'
+import {useRouter} from 'next/router'
+import type {ClientPerspective} from 'next-sanity'
+import {useEffect, useState} from 'react'
 
 export default function PreviewProvider({
   children,
@@ -9,8 +12,23 @@ export default function PreviewProvider({
   token: string
 }) {
   if (!token) throw new TypeError('Missing token')
+
+  const router = useRouter()
+
+  const [perspective, setPerspective] = useState<Exclude<ClientPerspective, 'raw'>>('previewDrafts')
+  useEffect(() => {
+    const maybePerspective = router.query['sanity-preview-perspective'] as any
+    if (router.isReady && maybePerspective) {
+      setPerspective(
+        (maybePerspective.includes(',')
+          ? maybePerspective.split(',')
+          : maybePerspective) as unknown as Exclude<ClientPerspective, 'raw'>,
+      )
+    }
+  }, [router.isReady, router.query])
+
   return (
-    <LiveQueryProvider client={client} token={token} logger={console}>
+    <LiveQueryProvider client={client} token={token} logger={console} perspective={perspective}>
       {children}
     </LiveQueryProvider>
   )

--- a/apps/remix/app/routes/api.draft.tsx
+++ b/apps/remix/app/routes/api.draft.tsx
@@ -9,11 +9,14 @@ export async function loader({request}: LoaderFunctionArgs) {
     throw new TypeError(`Missing SANITY_API_READ_TOKEN`)
   }
   session.set('view', 'previewDrafts')
+  const url = new URL(request.url)
+  url.searchParams.delete('sanity-preview-secret')
+  url.searchParams.delete('sanity-preview-pathname')
 
   return new Response(null, {
     status: 307,
     headers: {
-      'Location': '/',
+      'Location': `/?${url.searchParams}`,
       'Set-Cookie': await commitSession(session),
     },
   })

--- a/apps/remix/app/sanity.ts
+++ b/apps/remix/app/sanity.ts
@@ -1,3 +1,4 @@
+import type {ClientPerspective} from '@sanity/client/csm'
 import {createClient, type QueryParams} from '@sanity/preview-kit/client'
 
 const projectId = 'pv8y60vp'
@@ -23,10 +24,12 @@ export async function sanityFetch<QueryResponse>({
   previewDrafts,
   query,
   params = DEFAULT_PARAMS,
+  perspective,
 }: {
   previewDrafts?: boolean
   query: string
   params?: QueryParams
+  perspective?: ClientPerspective
 }): Promise<QueryResponse> {
   if (previewDrafts && !token) {
     throw new Error('The `SANITY_API_READ_TOKEN` environment variable is required.')
@@ -37,7 +40,7 @@ export async function sanityFetch<QueryResponse>({
     previewDrafts
       ? {
           token,
-          perspective: 'previewDrafts',
+          perspective,
         }
       : {},
   )

--- a/apps/remix/app/variants/live-store/PreviewProvider.tsx
+++ b/apps/remix/app/variants/live-store/PreviewProvider.tsx
@@ -1,4 +1,4 @@
-import {createClient} from '@sanity/client'
+import {createClient, type ClientPerspective} from '@sanity/client'
 import {LiveQueryProvider} from '@sanity/preview-kit'
 import {useState} from 'react'
 
@@ -6,10 +6,12 @@ export default function PreviewProvider({
   children,
   studioUrl,
   token,
+  perspective,
 }: {
   children: React.ReactNode
   studioUrl: string
   token: string
+  perspective: Exclude<ClientPerspective, 'raw'>
 }) {
   if (!token) throw new TypeError('Missing token')
   if (!studioUrl) throw new TypeError('Missing studioUrl')
@@ -32,7 +34,7 @@ export default function PreviewProvider({
     })
   })
   return (
-    <LiveQueryProvider client={client} token={token} logger={console}>
+    <LiveQueryProvider client={client} token={token} logger={console} perspective={perspective}>
       {children}
     </LiveQueryProvider>
   )

--- a/apps/remix/app/variants/live-store/index.tsx
+++ b/apps/remix/app/variants/live-store/index.tsx
@@ -11,10 +11,11 @@ export default function LiveStoreVariant({
   children,
   token,
   studioUrl,
+  perspective,
 }: SerializeFrom<typeof loader> & React.PropsWithChildren) {
   return previewDrafts ? (
     <StrictMode>
-      <PreviewProvider token={token!} studioUrl={studioUrl}>
+      <PreviewProvider token={token!} studioUrl={studioUrl} perspective={perspective}>
         {children}
       </PreviewProvider>
       <VisualEditing />

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
       ]
     },
     "overrides": {
-      "@sanity/vision": "corel",
+      "@sanity/vision": "3.59.2-corel-fix-presentation-perspective-switching.536",
       "@types/react": "latest",
       "@types/react-dom": "latest",
-      "sanity": "corel",
+      "sanity": "3.59.2-corel-fix-presentation-perspective-switching.536",
       "sanity-plugin-iframe-pane": "corel"
     }
   }

--- a/packages/preview-kit/package.json
+++ b/packages/preview-kit/package.json
@@ -85,7 +85,8 @@
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": "@sanity/prettier-config",
   "dependencies": {
-    "@sanity/preview-kit-compat": "1.5.36",
+    "@sanity/comlink": "^3.0.1",
+    "@sanity/presentation-comlink": "^1.0.3",
     "mendoza": "3.0.8"
   },
   "devDependencies": {

--- a/packages/preview-kit/src/LiveQueryProvider/usePerspective.ts
+++ b/packages/preview-kit/src/LiveQueryProvider/usePerspective.ts
@@ -1,0 +1,39 @@
+import type {ClientPerspective} from '@sanity/client'
+import {createNode, createNodeMachine} from '@sanity/comlink'
+import {
+  createCompatibilityActors,
+  type LoaderControllerMsg,
+  type LoaderNodeMsg,
+} from '@sanity/presentation-comlink'
+import {useEffect, useState} from 'react'
+
+export function usePerspective(
+  initialPerspective: Exclude<ClientPerspective, 'raw'>,
+): Exclude<ClientPerspective, 'raw'> {
+  const [presentationPerspective, setPresentationPerspective] = useState<Exclude<
+    ClientPerspective,
+    'raw'
+  > | null>(null)
+
+  useEffect(() => {
+    const comlink = createNode<LoaderNodeMsg, LoaderControllerMsg>(
+      {
+        name: 'loaders',
+        connectTo: 'presentation',
+      },
+      createNodeMachine<LoaderNodeMsg, LoaderControllerMsg>().provide({
+        actors: createCompatibilityActors<LoaderNodeMsg>(),
+      }),
+    )
+
+    comlink.on('loader/perspective', (data) => {
+      if (data.perspective !== 'raw') {
+        setPresentationPerspective(data.perspective)
+      }
+    })
+
+    const stop = comlink.start()
+    return () => stop()
+  }, [])
+  return presentationPerspective === null ? initialPerspective : presentationPerspective
+}

--- a/packages/preview-kit/src/client/index.test.ts
+++ b/packages/preview-kit/src/client/index.test.ts
@@ -22,7 +22,7 @@ test('it returns stega encoded source maps', async () => {
   expect(vercelStegaDecode(resultArray[0].title)).toMatchInlineSnapshot(
     `
     {
-      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=0074e292-efcf-45c2-aeb8-f680da2277ff;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=0074e292-efcf-45c2-aeb8-f680da2277ff&type=page&path=title&perspective=published",
+      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee&type=page&path=title&perspective=published",
       "origin": "sanity.io",
     }
   `,
@@ -32,7 +32,7 @@ test('it returns stega encoded source maps', async () => {
   expect(vercelStegaDecode(resultObject.title)).toMatchInlineSnapshot(
     `
     {
-      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=0074e292-efcf-45c2-aeb8-f680da2277ff;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=0074e292-efcf-45c2-aeb8-f680da2277ff&type=page&path=title&perspective=published",
+      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee&type=page&path=title&perspective=published",
       "origin": "sanity.io",
     }
   `,
@@ -41,7 +41,7 @@ test('it returns stega encoded source maps', async () => {
   const resultString = await client.fetch(`*[_type == "page" && title == $title][0].title`, {title})
   expect(vercelStegaDecode(resultString)).toMatchInlineSnapshot(`
     {
-      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=0074e292-efcf-45c2-aeb8-f680da2277ff;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=0074e292-efcf-45c2-aeb8-f680da2277ff&type=page&path=title&perspective=published",
+      "href": "https://preview-kit-test-studio.sanity.build/intent/edit/mode=presentation;id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee;type=page;path=title?baseUrl=https%3A%2F%2Fpreview-kit-test-studio.sanity.build&id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee&type=page&path=title&perspective=published",
       "origin": "sanity.io",
     }
   `)
@@ -65,7 +65,7 @@ test('it can access the original source map', async () => {
   )
   expect(vercelStegaDecode(result)).toMatchInlineSnapshot(`
     {
-      "href": "/studio/intent/edit/mode=presentation;id=0074e292-efcf-45c2-aeb8-f680da2277ff;type=page;path=title?baseUrl=%2Fstudio&id=0074e292-efcf-45c2-aeb8-f680da2277ff&type=page&path=title&perspective=published",
+      "href": "/studio/intent/edit/mode=presentation;id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee;type=page;path=title?baseUrl=%2Fstudio&id=abbba612-5449-42fc-b3f4-f4ec8a98c6ee&type=page&path=title&perspective=published",
       "origin": "sanity.io",
     }
   `)
@@ -73,7 +73,7 @@ test('it can access the original source map', async () => {
     {
       "documents": [
         {
-          "_id": "0074e292-efcf-45c2-aeb8-f680da2277ff",
+          "_id": "abbba612-5449-42fc-b3f4-f4ec8a98c6ee",
           "_type": "page",
         },
       ],
@@ -116,7 +116,7 @@ test('it can query the content source map without transcoding', async () => {
     {
       "documents": [
         {
-          "_id": "0074e292-efcf-45c2-aeb8-f680da2277ff",
+          "_id": "abbba612-5449-42fc-b3f4-f4ec8a98c6ee",
           "_type": "page",
         },
       ],

--- a/packages/preview-kit/src/hooks.ts
+++ b/packages/preview-kit/src/hooks.ts
@@ -1,6 +1,5 @@
-import type {QueryParams as ClientQueryParams} from '@sanity/client'
-import {useQueryParams} from '@sanity/preview-kit-compat'
-import {useCallback, useContext, useMemo, useState} from 'react'
+import type {QueryParams as ClientQueryParams, QueryParams} from '@sanity/client'
+import {useCallback, useContext, useEffect, useMemo, useState, useSyncExternalStore} from 'react'
 import isFastEqual from 'react-fast-compare'
 import {useSyncExternalStoreWithSelector} from 'use-sync-external-store/with-selector.js'
 
@@ -100,4 +99,125 @@ export function useLiveQuery<
  */
 export function useIsEnabled(): boolean {
   return useContext(defineStoreContext) !== null
+}
+
+/**
+ * Return params that are stable with deep equal as long as the key order is the same
+ * @internal
+ */
+export function useQueryParams(params?: undefined | null | QueryParams): QueryParams {
+  const stringifiedParams = useMemo(() => JSON.stringify(params || {}), [params])
+  return useMemo(() => JSON.parse(stringifiedParams) as QueryParams, [stringifiedParams])
+}
+
+/**
+ * 'hit' - the cache is fresh and valid
+ * 'stale' - the cache should revalidate, but can't/shouldn't yet (offline, visibility = hidden)
+ * 'refresh' - stale cache, and now is a great time to start refreshing
+ * 'inflight' - refreshing cache, revalidate events should be ignored
+ */
+export type RevalidateState = 'hit' | 'stale' | 'refresh' | 'inflight'
+/**
+ * Keeps track of when queries should revalidate
+ */
+export function useRevalidate(props: {
+  /**
+   * How frequently queries should be refetched in the background to refresh the parts of queries that can't be source mapped.
+   * Setting it to `0` will disable background refresh.
+   */
+  refreshInterval: number
+}): [RevalidateState, () => () => void] {
+  const {refreshInterval} = props
+
+  const shouldPause = useShouldPause()
+  const [state, setState] = useState<RevalidateState>('hit')
+
+  // Keep track of indicators for when revalidation should be 'paused'
+  // Like if we're currently offline, or the document isn't visible
+  // Basically if 'stale' and all good we return 'refresh'
+
+  // Next keep track of staleness itself. If we come back online, on a windows focus event
+  // or on a refreshInterval timeout
+  // Basically it controls if cache should be 'hit' or 'stale'
+
+  // How to handle refresh to inflight?
+
+  const startRefresh = useCallback(() => {
+    setState('inflight')
+    return () => setState('hit')
+  }, [])
+
+  // Revalidate on refreshInterval
+  useEffect(() => {
+    // If refreshInterval is nullish then we don't want to refresh.
+    // Inflight means it's already refreshing and we pause the countdown.
+    // It's only necessary to start the countdown if the cache isn't already stale
+    if (!refreshInterval || state !== 'hit') {
+      return
+    }
+    const timeout = setTimeout(() => setState('stale'), refreshInterval)
+    return () => clearTimeout(timeout)
+  }, [refreshInterval, state])
+  // Revalidate on windows focus
+  useEffect(() => {
+    if (state !== 'hit') {
+      return
+    }
+    const onFocus = () => setState('stale')
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [refreshInterval, state])
+  // Revalidate on changes to shouldPause
+  useEffect(() => {
+    // Mark as stale pre-emptively if we're offline or the document isn't visible
+    if (shouldPause && state === 'hit') {
+      setState('stale')
+    }
+    // If not paused we can mark stale as ready for refresh
+    if (!shouldPause && state === 'stale') {
+      setState('refresh')
+    }
+  }, [shouldPause, state])
+
+  return [state, startRefresh]
+}
+
+/**
+ * Keeps track of when revalidation and activities should be paused
+ */
+function useShouldPause(): boolean {
+  const [online, setOnline] = useState(false)
+  useEffect(() => {
+    setOnline(navigator.onLine)
+    const online = () => setOnline(true)
+    const offline = () => setOnline(false)
+    window.addEventListener('online', online)
+    window.addEventListener('offline', offline)
+    return () => {
+      window.removeEventListener('online', online)
+      window.removeEventListener('offline', offline)
+    }
+  }, [])
+  const visibilityState = useSyncExternalStore(
+    onVisibilityChange,
+    () => document.visibilityState,
+    () => 'hidden' satisfies DocumentVisibilityState,
+  )
+
+  // Should pause activity when offline
+  if (!online) {
+    return true
+  }
+
+  // Should pause when the document isn't visible, as it's likely the user isn't looking at the page
+  if (visibilityState === 'hidden') {
+    return true
+  }
+
+  return false
+}
+
+function onVisibilityChange(onStoreChange: () => void): () => void {
+  document.addEventListener('visibilitychange', onStoreChange)
+  return () => document.removeEventListener('visibilitychange', onStoreChange)
 }

--- a/packages/preview-kit/src/live-query/client-component/useLiveQuery.ts
+++ b/packages/preview-kit/src/live-query/client-component/useLiveQuery.ts
@@ -3,10 +3,10 @@
 
 import type {QueryParams as ClientQueryParams} from '@sanity/client'
 import type {QueryEnabled} from '@sanity/preview-kit'
-import {useQueryParams} from '@sanity/preview-kit-compat'
 import {useCallback, useContext, useMemo, useState, useSyncExternalStore} from 'react'
 
 import {defineStoreContext} from '../../context'
+import {useQueryParams} from '../../hooks'
 
 /** @internal */
 export function useLiveQuery<

--- a/packages/preview-kit/src/types.ts
+++ b/packages/preview-kit/src/types.ts
@@ -1,4 +1,4 @@
-import type {QueryParams, SanityClient} from '@sanity/client'
+import type {ClientPerspective, QueryParams, SanityClient} from '@sanity/client'
 import type {SanityStegaClient} from '@sanity/client/stega'
 
 /**
@@ -78,6 +78,10 @@ export interface LiveQueryProviderProps {
    */
   refreshInterval?: number
   logger?: Logger
+  /**
+   * @defaultValue 'previewDrafts'
+   */
+  perspective?: Exclude<ClientPerspective, 'raw'>
 }
 
 /** @public */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,10 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@sanity/vision': corel
+  '@sanity/vision': 3.59.2-corel-fix-presentation-perspective-switching.536
   '@types/react': latest
   '@types/react-dom': latest
-  sanity: corel
+  sanity: 3.59.2-corel-fix-presentation-perspective-switching.536
   sanity-plugin-iframe-pane: corel
 
 importers:
@@ -46,8 +46,8 @@ importers:
         specifier: 15.1.6
         version: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-sanity:
-        specifier: 9.8.40
-        version: 9.8.40(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 9.8.41
+        version: 9.8.41(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -104,8 +104,8 @@ importers:
         specifier: 15.1.6
         version: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next-sanity:
-        specifier: 9.8.40
-        version: 9.8.40(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 9.8.41
+        version: 9.8.41(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -218,10 +218,10 @@ importers:
         version: 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/vercel-protection-bypass':
         specifier: 1.0.5
-        version: 1.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 1.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@sanity/vision':
-        specifier: corel
-        version: 3.71.1-corel.541(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        specifier: 3.59.2-corel-fix-presentation-perspective-switching.536
+        version: 3.59.2-corel-fix-presentation-perspective-switching.536(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@types/react':
         specifier: latest
         version: 19.0.8
@@ -242,7 +242,7 @@ importers:
         version: 3.71.1
       groqd-playground:
         specifier: 0.0.20
-        version: 0.0.20(@sanity/icons@3.5.7(react@19.0.0))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 0.0.20(@sanity/icons@3.5.7(react@19.0.0))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -250,11 +250,11 @@ importers:
         specifier: 19.0.0
         version: 19.0.0(react@19.0.0)
       sanity:
-        specifier: corel
-        version: 3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+        specifier: 3.59.2-corel-fix-presentation-perspective-switching.536
+        version: 3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)
       sanity-plugin-iframe-pane:
         specifier: corel
-        version: 3.1.6-corel.1(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+        version: 3.1.6-corel.1(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       styled-components:
         specifier: 6.1.14
         version: 6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -264,9 +264,12 @@ importers:
 
   packages/preview-kit:
     dependencies:
-      '@sanity/preview-kit-compat':
-        specifier: 1.5.36
-        version: 1.5.36(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))(react@19.0.0)
+      '@sanity/comlink':
+        specifier: ^3.0.1
+        version: 3.0.1
+      '@sanity/presentation-comlink':
+        specifier: ^1.0.3
+        version: 1.0.3(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))
       mendoza:
         specifier: 3.0.8
         version: 3.0.8
@@ -2380,6 +2383,11 @@ packages:
   '@sanity/browserslist-config@1.0.5':
     resolution: {integrity: sha512-so+/UtCge8t1jq509hH0otbbptRz0zM/Aa0dh5MhMD7HGT6n2igWIL2VWH/9QR9e77Jn3dJsjz23mW1WCxT+sg==}
 
+  '@sanity/cli@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-FFTvtdpr9tSV1HjHU1eRYYIxzCUjjCXJ5aC23syfmEJCBBUS0iQkpBQHRsn/3i3vJwEO9alC30rVWM5n/e+Nww==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@sanity/cli@3.71.1-corel.541':
     resolution: {integrity: sha512-L4ZnSugh5LeXIg6l2YpLGll30shyUXiPjnFaAZdcXVSCIMzWx4sHXcXTCSSpvxeGwVbGREdRv3gXm9BUJsSIqg==}
     engines: {node: '>=18'}
@@ -2388,6 +2396,10 @@ packages:
   '@sanity/client@6.27.1':
     resolution: {integrity: sha512-cXRvXa6Sp/O2Bto0pCKhSfKxiF1ItO+PXwIKfKtMuUa35rgPWRzax9ddXNG0vR9k1Qggh4hn9yPZ8mstu4J2BA==}
     engines: {node: '>=14.18'}
+
+  '@sanity/codegen@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-MOYMqxNndHBIK+yZTVwRmI4JekVzlUZc17pGZOamb1BYF9Zp+03Cn4TXZnSW6vt2ndEbHD8IWpW101dEq8WBkA==}
+    engines: {node: '>=18'}
 
   '@sanity/codegen@3.71.1-corel.541':
     resolution: {integrity: sha512-RvzpcNaJjPkhsNzSJAtORcPBMIXY01QdVCiMyY/XeviLvcZ+2hvUsiZTU4J6NDZyO92pfLLf8V3cTvHcZjZ1jA==}
@@ -2404,6 +2416,10 @@ packages:
   '@sanity/diff-match-patch@3.2.0':
     resolution: {integrity: sha512-4hPADs0qUThFZkBK/crnfKKHg71qkRowfktBljH2UIxGHHTxIzt8g8fBiXItyCjxkuNy+zpYOdRMifQNv8+Yww==}
     engines: {node: '>=18.18'}
+
+  '@sanity/diff@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-OVIWgP7LNXZfCPb7T3yE3des1N3mkTRyoixsqEf1ndr0S84tQcK9AlqArWyKH5czvn4GJhWNRygofulxO6oXuA==}
+    engines: {node: '>=18'}
 
   '@sanity/diff@3.71.1-corel.541':
     resolution: {integrity: sha512-WgGd0Hf4kw0/+QsVJsulTY1yBCW3DpDV7wFu/lep+fo524HwLawwY/GJOz5pjvDbkBsvoF52RwGwhZGJx0ZbRg==}
@@ -2456,6 +2472,10 @@ packages:
       '@sanity/color': ^2.0 || ^3.0 || ^3.0.0-beta
       react: ^18.3 || >=19.0.0-rc
 
+  '@sanity/migrate@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-8oCILIv8F8rT6OwSUnQaEWSVcHWeGdCaO7uQtqHR5kKU9IWj/yuYLxcrCWTc8dSDj8hMCWFkM3GE7AIBLa6O3w==}
+    engines: {node: '>=18'}
+
   '@sanity/migrate@3.71.1-corel.541':
     resolution: {integrity: sha512-+D0DlVhcJawQyEaFhBNidaynPMoMyRdJqeND+AjpuPj7d+UagUzgjSgZe77X8AuNeqflTNfMLBaf1S+BtM9TKg==}
     engines: {node: '>=18'}
@@ -2473,14 +2493,17 @@ packages:
     resolution: {integrity: sha512-SuOpMOEwcTcE5fFHpy44qVuGs8NeBAOF8wwN5DYz0Jl4MJZWGsUS81YUeFwQl0XqBZpfiLVzwutp1KYCZPuqUQ==}
     engines: {node: '>=18'}
 
+  '@sanity/mutator@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-LeD+RakYC0bFEkOBVuKsn3Ba9a0xGGmnkC61JN8l2DPiV0glFuls5+gcJxrS/3zTSZFG7zL4V1f6TtzipV7dmA==}
+
   '@sanity/mutator@3.71.1':
     resolution: {integrity: sha512-Xw3W29/q+ToESvli0Rs6Po+PIhs89yXfReoI4RoXc8UBRdvPTNDu3Z6eao9OfC0qFjpyaMv6Cwnz/idssMlWJg==}
 
   '@sanity/mutator@3.71.1-corel.541':
     resolution: {integrity: sha512-CFZ82C9l9tAJLkiKudRPB814pDK2L37amYWlxso2fImyXeFSLiDKUlyhgtcOXB72AL7ayS3IfakcXDTPBzi2Ww==}
 
-  '@sanity/next-loader@1.2.18':
-    resolution: {integrity: sha512-XHoubMJscwEqs1j1WSU5w82SqIpiVV/yxEB7OL64U6gfj/yhYJSjoDdXXvgXZHvCrECkPB8Ghqa9pshAyk0xWQ==}
+  '@sanity/next-loader@1.2.19':
+    resolution: {integrity: sha512-JqZQ1pz3E/C2Q74ZGAjNxVXmeOMMuDLhWpGKnGeFiebMSM9UTG+JdNAFQFtKMQjpLF2P6/Gmwe3TW/GNaqe8fw==}
     engines: {node: '>=18.18'}
     peerDependencies:
       next: ^14.1 || ^15.0.0-0
@@ -2548,6 +2571,15 @@ packages:
     peerDependencies:
       '@sanity/client': ^6.27.0
 
+  '@sanity/preview-url-secret@2.1.3':
+    resolution: {integrity: sha512-bTKldUIXoUP2PLz2yRY4dFL/wOinEB/Tn1DS1SD9Acy3oDpmXI4WOPeo0kw5uDHBN3rNZV+nAkNk1tPvIjVtgg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@sanity/client': ^6.27.1
+
+  '@sanity/schema@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-h1O/d9wnngzzMzXJI3zW0m6dah6CfVDTuSR3nRBCEAyWdhua9tT5+siuXMTt92h2AA1BsBa6YjPlBYrFy0nxeQ==}
+
   '@sanity/schema@3.71.1-corel.541':
     resolution: {integrity: sha512-3saE5ZnYqZ+LyW5cUPixU9jSxiFh3FPhzmI1npVmopl8tWHUooOnp9ckaclXAsfzkkVjgY9j0i01Gwz7zbmAeg==}
 
@@ -2567,6 +2599,11 @@ packages:
     resolution: {integrity: sha512-eGWNXVBZbDcCOvmco4kE6gW6BwZUT9necgt8esdUHo5rFUBphAPl26rCzCNHUjjCGWWLs1ExMwtMkRIAxOT2Ow==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  '@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-5sU9Y27Mx1wBgHfOPt4A4jXGWyxk0OTteK4xvBCRCyuRJCdZrR/kWe7WUjfuRHQhwxfJ961Qj2rqPjJIBtrWdA==}
+    peerDependencies:
+      '@types/react': latest
 
   '@sanity/types@3.68.3':
     resolution: {integrity: sha512-JemibQXC08rHIXgjUH/p2TCiiD9wq6+dDkCvVHOooCvaYZNhAe2S9FAEkaA6qwWtPzyY2r6/tj1eDgNeLgXN1Q==}
@@ -2592,6 +2629,10 @@ packages:
       react-is: ^18 || >=19.0.0-0
       styled-components: ^5.2 || ^6
 
+  '@sanity/util@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-7VWVW0o4/EbLDX1FnL5ZB65sxCRCFpKrqoIq5v5Koz4hw3n8mPJqIR/P0AOOpt7CA+sGK9Gs7hF6v24J4q3qew==}
+    engines: {node: '>=18'}
+
   '@sanity/util@3.68.3':
     resolution: {integrity: sha512-J4Ov75oUvMqx221VEJkKNSibzF0D8VyCzejtwftW+jP80XguYFqBz7bAcTmwJ5vnxNUoAUCeAdZBoOYVpgew4g==}
     engines: {node: '>=18'}
@@ -2608,10 +2649,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18.3 || ^19
-      sanity: corel
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536
 
-  '@sanity/vision@3.71.1-corel.541':
-    resolution: {integrity: sha512-PqLVjGZ6Nkfoy7iRRzNl0tbG6UlsJnvRt8Mlb3rYD9JzQ0HYyjgL+w6jcOchzbKTC6AZcffCqAIjsiTFuh/fgw==}
+  '@sanity/vision@3.59.2-corel-fix-presentation-perspective-switching.536':
+    resolution: {integrity: sha512-aKSHyzxLgGrt3hZrQep/uz2QoNsMDlJlQET9So8t298D/ac/TeulqcbFPjx3OA/p6rN3t0DlzY72XlcBVreLvQ==}
     peerDependencies:
       react: ^18 || ^19.0.0
       styled-components: ^6.1
@@ -2638,6 +2679,32 @@ packages:
     peerDependencies:
       '@remix-run/react': '>= 2'
       '@sanity/client': ^6.27.0
+      '@sveltejs/kit': '>= 2'
+      next: '>= 13 || >=14.3.0-canary.0 <14.3.0 || >=15.0.0-rc'
+      react: ^18.3 || >=19.0.0-rc
+      react-dom: ^18.3 || >=19.0.0-rc
+      react-router: '>= 7'
+      svelte: '>= 4'
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sanity/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      svelte:
+        optional: true
+
+  '@sanity/visual-editing@2.12.8':
+    resolution: {integrity: sha512-Q6tFElhKKW3EYjRdKgO0XaTip3kThDbFI2Q/L+p4FVNVWel48oq6rk6YR88Dt2IuJZErg4mAaMptpCXQ2iqjyA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@remix-run/react': '>= 2'
+      '@sanity/client': ^6.27.1
       '@sveltejs/kit': '>= 2'
       next: '>= 13 || >=14.3.0-canary.0 <14.3.0 || >=15.0.0-rc'
       react: ^18.3 || >=19.0.0-rc
@@ -4902,6 +4969,10 @@ packages:
     resolution: {integrity: sha512-1CtOqgATOhmB6jRKL6zvojb2Vt8aP2y6m/7ZN4JlpFhyB/d8WRW3/kZgapIUHys6/Vrkk1oTbjjDbxNL8QxHSQ==}
     engines: {node: '>= 14'}
 
+  groq@3.59.2-corel-fix-presentation-perspective-switching.536:
+    resolution: {integrity: sha512-ZFTJ/zTctW0svXb1Qq3RSLaMSeiT4B4k9+tFpSJeOSFnY3Qt8mpoqHv5MLo9BpDzlY78goL8Sj+DoGj/+porBg==}
+    engines: {node: '>=18'}
+
   groq@3.71.1:
     resolution: {integrity: sha512-756GxrNoG/OCmoXATnVjDCxB3xNN4QHariFuoUOtoJ/kQEJ6qhOyW2hn2OgOXM23GZZ2VKM+99KkkQ084XRuag==}
     engines: {node: '>=18'}
@@ -4918,7 +4989,7 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
       react-is: ^18.2.0
-      sanity: corel
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536
       styled-components: ^5.2 || ^6
 
   groqd@0.15.12:
@@ -6120,8 +6191,8 @@ packages:
   nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
 
-  next-sanity@9.8.40:
-    resolution: {integrity: sha512-cqaHYERSR1b/ViGEnaBhCdBkPTkI7JOSlt13j+WF5FgBAGCjfnzl1TSpeX8qj5Igk6amWxook1doPM3rIuH59g==}
+  next-sanity@9.8.41:
+    resolution: {integrity: sha512-QDxnyrzSJVg7gvK3KOn6IvbcUDHyko+9fsoAaU8esIY7MG9PS4c5eIrTINCz+DMzzSCfW582CWlRB5EHLy2DUw==}
     engines: {node: '>=18.18'}
     peerDependencies:
       '@sanity/client': ^6.27.1
@@ -6130,7 +6201,7 @@ packages:
       '@sanity/ui': ^2.11.4
       next: ^14.2 || ^15.0.0-0
       react: ^18.3 || ^19.0.0-0
-      sanity: corel
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536
       styled-components: ^6.1
 
   next@15.1.6:
@@ -7237,8 +7308,17 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       react: ^18.2.0
-      sanity: corel
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536
       styled-components: ^5.2 || ^6.0.0
+
+  sanity@3.59.2-corel-fix-presentation-perspective-switching.536:
+    resolution: {integrity: sha512-qalaePlgnqH6Min1Vi9TtAbpTZ5TRpxxGwhvG8TMA89fTXGN/jdDL5fUfi+HOG1GEFSkHZCBpJ+ao2eVZmAGPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      react: ^18 || ^19.0.0
+      react-dom: ^18 || ^19.0.0
+      styled-components: ^6.1
 
   sanity@3.71.1-corel.541:
     resolution: {integrity: sha512-mOlSYghJcYq+PIYg0wJSy3dbNX2mRgoIh+eGVal/tn6K6F7eH3bApoggIvyC5tW+KCGnSkvd0wesCIW+9wFMkQ==}
@@ -10209,12 +10289,44 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@portabletext/block-tools@1.1.2(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)':
+    dependencies:
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@types/react': 19.0.8
+      get-random-values-esm: 1.0.2
+      lodash: 4.17.21
+
   '@portabletext/block-tools@1.1.2(@sanity/types@3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)':
     dependencies:
       '@sanity/types': 3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0)
       '@types/react': 19.0.8
       get-random-values-esm: 1.0.2
       lodash: 4.17.21
+
+  '@portabletext/editor@1.25.0(@sanity/schema@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)':
+    dependencies:
+      '@portabletext/block-tools': 1.1.2(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)
+      '@portabletext/patches': 1.1.2
+      '@portabletext/to-html': 2.0.13
+      '@sanity/schema': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@xstate/react': 5.0.2(@types/react@19.0.8)(react@19.0.0)(xstate@5.19.2)
+      debug: 4.4.0
+      get-random-values-esm: 1.0.2
+      lodash: 4.17.21
+      lodash.startcase: 4.4.0
+      react: 19.0.0
+      react-compiler-runtime: 19.0.0-beta-decd7b8-20250118(react@19.0.0)
+      rxjs: 7.8.1
+      slate: 0.112.0
+      slate-dom: 0.111.0(slate@0.112.0)
+      slate-react: 0.112.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(slate-dom@0.111.0(slate@0.112.0))(slate@0.112.0)
+      use-effect-event: 1.0.2(react@19.0.0)
+      xstate: 5.19.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - react-dom
+      - supports-color
 
   '@portabletext/editor@1.25.0(@sanity/schema@3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0))(@sanity/types@3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)':
     dependencies:
@@ -10351,7 +10463,7 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       eslint-plugin-jest: 26.9.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
       eslint-plugin-jest-dom: 4.0.3(eslint@8.57.1)
@@ -10666,6 +10778,34 @@ snapshots:
 
   '@sanity/browserslist-config@1.0.5': {}
 
+  '@sanity/cli@3.59.2-corel-fix-presentation-perspective-switching.536(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)':
+    dependencies:
+      '@babel/traverse': 7.26.5
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/codegen': 3.59.2-corel-fix-presentation-perspective-switching.536
+      '@sanity/telemetry': 0.7.9(react@19.0.0)
+      '@sanity/template-validator': 2.3.2(@types/babel__core@7.20.5)(@types/node@18.19.71)(debug@4.4.0)(typescript@5.7.3)
+      '@sanity/util': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      chalk: 4.1.2
+      debug: 4.4.0
+      decompress: 4.2.1
+      esbuild: 0.21.5
+      esbuild-register: 3.6.0(esbuild@0.21.5)
+      get-it: 8.6.6(debug@4.4.0)
+      groq-js: 1.14.2
+      pkg-dir: 5.0.0
+      prettier: 3.4.2
+      semver: 7.6.3
+      validate-npm-package-name: 3.0.0
+    transitivePeerDependencies:
+      - '@types/babel__core'
+      - '@types/node'
+      - '@types/react'
+      - babel-plugin-react-compiler
+      - react
+      - supports-color
+      - typescript
+
   '@sanity/cli@3.71.1-corel.541(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)':
     dependencies:
       '@babel/traverse': 7.26.5
@@ -10702,6 +10842,26 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@sanity/codegen@3.59.2-corel-fix-presentation-perspective-switching.536':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/generator': 7.26.5
+      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
+      '@babel/preset-react': 7.26.3(@babel/core@7.26.0)
+      '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
+      '@babel/register': 7.25.9(@babel/core@7.26.0)
+      '@babel/traverse': 7.26.5
+      '@babel/types': 7.26.5
+      debug: 4.4.0
+      globby: 11.1.0
+      groq: 3.59.2-corel-fix-presentation-perspective-switching.536
+      groq-js: 1.14.2
+      json5: 2.2.3
+      tsconfig-paths: 4.2.0
+      zod: 3.24.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@sanity/codegen@3.71.1-corel.541':
     dependencies:
       '@babel/core': 7.26.0
@@ -10731,6 +10891,10 @@ snapshots:
       xstate: 5.19.2
 
   '@sanity/diff-match-patch@3.2.0': {}
+
+  '@sanity/diff@3.59.2-corel-fix-presentation-perspective-switching.536':
+    dependencies:
+      '@sanity/diff-match-patch': 3.2.0
 
   '@sanity/diff@3.71.1-corel.541':
     dependencies:
@@ -10802,6 +10966,19 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
+  '@sanity/insert-menu@1.0.19(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      '@sanity/icons': 3.5.7(react@19.0.0)
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      lodash: 4.17.21
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-is: 18.3.1
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - styled-components
+
   '@sanity/insert-menu@1.0.19(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.5.7(react@19.0.0)
@@ -10819,6 +10996,21 @@ snapshots:
     dependencies:
       '@sanity/color': 3.0.6
       react: 19.0.0
+
+  '@sanity/migrate@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/mutate': 0.12.1(debug@4.4.0)
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/util': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      arrify: 2.0.1
+      debug: 4.4.0
+      fast-fifo: 1.3.2
+      groq-js: 1.14.2
+      p-map: 7.0.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
 
   '@sanity/migrate@3.71.1-corel.541(@types/react@19.0.8)':
     dependencies:
@@ -10862,6 +11054,17 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  '@sanity/mutator@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)':
+    dependencies:
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/uuid': 3.0.2
+      debug: 4.4.0
+      lodash: 4.17.21
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   '@sanity/mutator@3.71.1(@types/react@19.0.8)':
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
@@ -10884,7 +11087,7 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@sanity/next-loader@1.2.18(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@sanity/next-loader@1.2.19(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@sanity/client': 6.27.1(debug@4.4.0)
       '@sanity/comlink': 3.0.1
@@ -10996,6 +11199,14 @@ snapshots:
       - debug
       - supports-color
 
+  '@sanity/presentation-comlink@1.0.3(@sanity/client@6.27.1)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/comlink': 3.0.1
+      '@sanity/visual-editing-types': 1.0.3(@sanity/client@6.27.1)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))
+    transitivePeerDependencies:
+      - '@sanity/types'
+
   '@sanity/presentation-comlink@1.0.3(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))':
     dependencies:
       '@sanity/client': 6.27.1(debug@4.4.0)
@@ -11046,6 +11257,26 @@ snapshots:
       '@sanity/client': 6.27.1(debug@4.4.0)
       '@sanity/uuid': 3.0.2
 
+  '@sanity/preview-url-secret@2.1.3(@sanity/client@6.27.1)':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/uuid': 3.0.2
+
+  '@sanity/schema@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)':
+    dependencies:
+      '@sanity/generate-help-url': 3.0.0
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      arrify: 2.0.1
+      groq-js: 1.14.2
+      humanize-list: 1.0.1
+      leven: 3.1.0
+      lodash: 4.17.21
+      object-inspect: 1.13.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+      - supports-color
+
   '@sanity/schema@3.71.1-corel.541(@types/react@19.0.8)(debug@4.4.0)':
     dependencies:
       '@sanity/generate-help-url': 3.0.0
@@ -11093,6 +11324,13 @@ snapshots:
       - supports-color
       - typescript
 
+  '@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@types/react': 19.0.8
+    transitivePeerDependencies:
+      - debug
+
   '@sanity/types@3.68.3(@types/react@19.0.8)(debug@4.4.0)':
     dependencies:
       '@sanity/client': 6.27.1(debug@4.4.0)
@@ -11131,6 +11369,17 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
+  '@sanity/util@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      get-random-values-esm: 1.0.2
+      moment: 2.30.1
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - '@types/react'
+      - debug
+
   '@sanity/util@3.68.3(@types/react@19.0.8)(debug@4.4.0)':
     dependencies:
       '@sanity/client': 6.27.1(debug@4.4.0)
@@ -11158,14 +11407,14 @@ snapshots:
       '@types/uuid': 8.3.4
       uuid: 8.3.2
 
-  '@sanity/vercel-protection-bypass@1.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@sanity/vercel-protection-bypass@1.0.5(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@sanity/icons': 3.5.7(react@19.0.0)
       '@sanity/preview-url-secret': 2.1.2(@sanity/client@6.27.1)
       '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       react: 19.0.0
       react-compiler-runtime: 19.0.0-beta-decd7b8-20250118(react@19.0.0)
-      sanity: 3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@sanity/client'
@@ -11173,7 +11422,7 @@ snapshots:
       - react-is
       - styled-components
 
-  '@sanity/vision@3.71.1-corel.541(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+  '@sanity/vision@3.59.2-corel-fix-presentation-perspective-switching.536(@babel/runtime@7.26.0)(@codemirror/lint@6.8.4)(@codemirror/theme-one-dark@6.1.2)(@emotion/is-prop-valid@1.2.2)(codemirror@6.0.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
     dependencies:
       '@codemirror/autocomplete': 6.18.4
       '@codemirror/commands': 6.8.0
@@ -11216,6 +11465,12 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/types'
 
+  '@sanity/visual-editing-types@1.0.3(@sanity/client@6.27.1)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))':
+    dependencies:
+      '@sanity/client': 6.27.1(debug@4.4.0)
+    optionalDependencies:
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+
   '@sanity/visual-editing-types@1.0.3(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))':
     dependencies:
       '@sanity/client': 6.27.1(debug@4.4.0)
@@ -11234,6 +11489,30 @@ snapshots:
       '@sanity/mutate': 0.11.0-canary.4(xstate@5.19.2)
       '@sanity/presentation-comlink': 1.0.3(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))
       '@sanity/preview-url-secret': 2.1.2(@sanity/client@6.27.1)
+      '@sanity/visual-editing-csm': 2.0.1(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))
+      '@vercel/stega': 0.1.2
+      get-random-values-esm: 1.0.2
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      rxjs: 7.8.1
+      scroll-into-view-if-needed: 3.1.0
+      use-effect-event: 1.0.2(react@19.0.0)
+      valibot: 0.31.1
+      xstate: 5.19.2
+    optionalDependencies:
+      '@remix-run/react': 2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      next: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+    transitivePeerDependencies:
+      - '@sanity/types'
+      - debug
+
+  '@sanity/visual-editing@2.12.8(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@sanity/comlink': 3.0.1
+      '@sanity/mutate': 0.11.0-canary.4(xstate@5.19.2)
+      '@sanity/presentation-comlink': 1.0.3(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))
+      '@sanity/preview-url-secret': 2.1.3(@sanity/client@6.27.1)
       '@sanity/visual-editing-csm': 2.0.1(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))
       '@vercel/stega': 0.1.2
       get-random-values-esm: 1.0.2
@@ -11838,6 +12117,17 @@ snapshots:
       ts-morph: 12.0.0
 
   '@vercel/stega@0.1.2': {}
+
+  '@vitejs/plugin-react@4.3.4(vite@5.4.14(@types/node@18.19.71)(terser@5.37.0))':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
+      '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.14.2
+      vite: 5.4.14(@types/node@18.19.71)(terser@5.37.0)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@4.3.4(vite@6.0.11(@types/node@18.19.71)(terser@5.37.0)(yaml@2.7.0))':
     dependencies:
@@ -13244,22 +13534,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0
-      enhanced-resolve: 5.18.0
-      eslint: 8.57.1
-      fast-glob: 3.3.3
-      get-tsconfig: 4.10.0
-      is-bun-module: 1.3.0
-      is-glob: 4.0.3
-      stable-hash: 0.0.4
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -13276,14 +13550,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13315,7 +13589,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14138,11 +14412,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  groq@3.59.2-corel-fix-presentation-perspective-switching.536: {}
+
   groq@3.71.1: {}
 
   groq@3.71.1-corel.541: {}
 
-  groqd-playground@0.0.20(@sanity/icons@3.5.7(react@19.0.0))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+  groqd-playground@0.0.20(@sanity/icons@3.5.7(react@19.0.0))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
       '@sanity/icons': 3.5.7(react@19.0.0)
       '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
@@ -14152,7 +14428,7 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       react-is: 18.3.1
-      sanity: 3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)
       styled-components: 6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       zod: 3.24.1
 
@@ -15505,21 +15781,22 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next-sanity@9.8.40(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+  next-sanity@9.8.41(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/icons@3.5.7(react@19.0.0))(@sanity/types@3.71.1(@types/react@19.0.8))(@sanity/ui@2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
       '@portabletext/react': 3.2.0(react@19.0.0)
       '@sanity/client': 6.27.1(debug@4.4.0)
       '@sanity/icons': 3.5.7(react@19.0.0)
-      '@sanity/next-loader': 1.2.18(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@sanity/next-loader': 1.2.19(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       '@sanity/preview-kit': 5.1.32(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))(react@19.0.0)
-      '@sanity/preview-url-secret': 2.1.2(@sanity/client@6.27.1)
+      '@sanity/preview-url-secret': 2.1.3(@sanity/client@6.27.1)
       '@sanity/types': 3.71.1(@types/react@19.0.8)(debug@4.4.0)
       '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
-      '@sanity/visual-editing': 2.12.7(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@sanity/visual-editing': 2.12.8(@remix-run/react@2.15.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(@sanity/client@6.27.1)(@sanity/types@3.71.1(@types/react@19.0.8))(next@15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       groq: 3.71.1
       history: 5.3.0
       next: 15.1.6(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+      sanity: 3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
       styled-components: 6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@remix-run/react'
@@ -16616,7 +16893,7 @@ snapshots:
     dependencies:
       '@sanity/diff-match-patch': 3.2.0
 
-  sanity-plugin-iframe-pane@3.1.6-corel.1(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
+  sanity-plugin-iframe-pane@3.1.6-corel.1(@emotion/is-prop-valid@1.2.2)(@sanity/client@6.27.1)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3))(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)):
     dependencies:
       '@sanity/icons': 3.5.7(react@19.0.0)
       '@sanity/incompatible-plugin': 1.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -16624,7 +16901,7 @@ snapshots:
       '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       framer-motion: 11.0.8(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
-      sanity: 3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0)
+      sanity: 3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)
       styled-components: 6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       suspend-react: 0.1.3(react@19.0.0)
       usehooks-ts: 3.0.1(react@19.0.0)
@@ -16633,6 +16910,156 @@ snapshots:
       - '@sanity/client'
       - react-dom
       - react-is
+
+  sanity@3.59.2-corel-fix-presentation-perspective-switching.536(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3):
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@dnd-kit/modifiers': 6.0.1(@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.3.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      '@dnd-kit/utilities': 3.2.2(react@19.0.0)
+      '@juggle/resize-observer': 3.4.0
+      '@portabletext/block-tools': 1.1.2(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)
+      '@portabletext/editor': 1.25.0(@sanity/schema@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(rxjs@7.8.1)
+      '@portabletext/react': 3.2.0(react@19.0.0)
+      '@rexxars/react-json-inspector': 9.0.1(react@19.0.0)
+      '@sanity/asset-utils': 2.2.1
+      '@sanity/bifur-client': 0.4.1
+      '@sanity/cli': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react@19.0.0)(typescript@5.7.3)
+      '@sanity/client': 6.27.1(debug@4.4.0)
+      '@sanity/color': 3.0.6
+      '@sanity/comlink': 3.0.1
+      '@sanity/diff': 3.59.2-corel-fix-presentation-perspective-switching.536
+      '@sanity/diff-match-patch': 3.2.0
+      '@sanity/eventsource': 5.0.2
+      '@sanity/export': 3.42.2(@types/react@19.0.8)
+      '@sanity/icons': 3.5.7(react@19.0.0)
+      '@sanity/image-url': 1.1.0
+      '@sanity/import': 3.37.9(@types/react@19.0.8)
+      '@sanity/insert-menu': 1.0.19(@emotion/is-prop-valid@1.2.2)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@sanity/logos': 2.1.13(@sanity/color@3.0.6)(react@19.0.0)
+      '@sanity/migrate': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)
+      '@sanity/mutator': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)
+      '@sanity/presentation-comlink': 1.0.3(@sanity/client@6.27.1)(@sanity/types@3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0))
+      '@sanity/preview-url-secret': 2.1.2(@sanity/client@6.27.1)
+      '@sanity/schema': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/telemetry': 0.7.9(react@19.0.0)
+      '@sanity/types': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/ui': 2.11.4(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react-is@18.3.1)(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@sanity/util': 3.59.2-corel-fix-presentation-perspective-switching.536(@types/react@19.0.8)(debug@4.4.0)
+      '@sanity/uuid': 3.0.2
+      '@sentry/react': 8.51.0(react@19.0.0)
+      '@tanstack/react-table': 8.20.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@tanstack/react-virtual': 3.11.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@types/react-is': 19.0.0
+      '@types/shallow-equals': 1.0.3
+      '@types/speakingurl': 13.0.6
+      '@types/tar-stream': 3.1.3
+      '@types/use-sync-external-store': 0.0.6
+      '@vitejs/plugin-react': 4.3.4(vite@5.4.14(@types/node@18.19.71)(terser@5.37.0))
+      archiver: 7.0.1
+      arrify: 2.0.1
+      async-mutex: 0.4.1
+      chalk: 4.1.2
+      chokidar: 3.6.0
+      classnames: 2.5.1
+      color2k: 2.0.3
+      configstore: 5.0.1
+      console-table-printer: 2.12.1
+      dataloader: 2.2.3
+      date-fns: 2.30.0
+      debug: 4.4.0
+      esbuild: 0.21.5
+      esbuild-register: 3.6.0(esbuild@0.21.5)
+      execa: 2.1.0
+      exif-component: 1.0.1
+      fast-deep-equal: 3.1.3
+      form-data: 4.0.1
+      framer-motion: 11.18.2(@emotion/is-prop-valid@1.2.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      get-it: 8.6.6(debug@4.4.0)
+      get-random-values-esm: 1.0.2
+      groq-js: 1.14.2
+      history: 5.3.0
+      i18next: 23.16.8
+      import-fresh: 3.3.0
+      is-hotkey-esm: 1.0.0
+      isomorphic-dompurify: 2.20.0
+      jsdom: 23.2.0
+      jsdom-global: 3.0.2(jsdom@23.2.0)
+      json-lexer: 1.2.0
+      json-reduce: 3.0.0
+      json5: 2.2.3
+      lodash: 4.17.21
+      log-symbols: 2.2.0
+      mendoza: 3.0.8
+      mnemonist: 0.39.8
+      module-alias: 2.2.3
+      nano-pubsub: 3.0.0
+      nanoid: 3.3.8
+      node-html-parser: 6.1.13
+      observable-callback: 1.0.3(rxjs@7.8.1)
+      oneline: 1.0.3
+      open: 8.4.2
+      p-map: 7.0.3
+      path-to-regexp: 6.3.0
+      pirates: 4.0.6
+      pluralize-esm: 9.0.5
+      polished: 4.3.1
+      pretty-ms: 7.0.1
+      quick-lru: 5.1.1
+      raf: 3.4.1
+      react: 19.0.0
+      react-compiler-runtime: 19.0.0-beta-decd7b8-20250118(react@19.0.0)
+      react-dom: 19.0.0(react@19.0.0)
+      react-fast-compare: 3.2.2
+      react-focus-lock: 2.13.5(@types/react@19.0.8)(react@19.0.0)
+      react-i18next: 14.0.2(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-is: 18.3.1
+      react-refractor: 2.2.0(react@19.0.0)
+      react-rx: 4.1.16(react@19.0.0)(rxjs@7.8.1)
+      read-pkg-up: 7.0.1
+      refractor: 3.6.0
+      resolve-from: 5.0.0
+      resolve.exports: 2.0.3
+      rimraf: 5.0.10
+      rxjs: 7.8.1
+      rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.1)
+      rxjs-mergemap-array: 0.1.0(rxjs@7.8.1)
+      sanity-diff-patch: 4.0.0
+      scroll-into-view-if-needed: 3.1.0
+      semver: 7.6.3
+      shallow-equals: 1.0.0
+      speakingurl: 14.0.1
+      styled-components: 6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      suspend-react: 0.1.3(react@19.0.0)
+      tar-fs: 2.1.2
+      tar-stream: 3.1.7
+      use-device-pixel-ratio: 1.1.2(react@19.0.0)
+      use-effect-event: 1.0.2(react@19.0.0)
+      use-hot-module-reload: 2.0.0(react@19.0.0)
+      use-sync-external-store: 1.4.0(react@19.0.0)
+      uuid: 11.0.5
+      valibot: 0.31.1
+      vite: 5.4.14(@types/node@18.19.71)(terser@5.37.0)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - '@types/babel__core'
+      - '@types/node'
+      - '@types/react'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - canvas
+      - less
+      - lightningcss
+      - react-native
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - typescript
+      - utf-8-validate
 
   sanity@3.71.1-corel.541(@emotion/is-prop-valid@1.2.2)(@types/babel__core@7.20.5)(@types/node@18.19.71)(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(styled-components@6.1.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(terser@5.37.0)(typescript@5.7.3)(yaml@2.7.0):
     dependencies:


### PR DESCRIPTION
Adds a new `perspective` prop to `<LiveQueryProvider />` that lets you use any perspective you want, other than the default `previewDrafts`. This is relevant for Content Releases.

It also now integrates with Sanity Presentation and automatically applies the perspective used in your studio. On v3.71 and earlier of `sanity`, that means switching between `published` and `drafts`. 
In `sanity@corel` it means you can view any custom releases as well.